### PR TITLE
Add Tribute to House one-page site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# codex_tribute_to_house
+# Tribute to House Website
+
+This repository contains a simple one-page website for the "Tribute to House" music label. Open `index.html` in a browser to view the page. No build steps are required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tribute to House</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Montserrat:wght@300;400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <audio id="bg-audio" src="https://cdn.pixabay.com/download/audio/2022/03/23/audio_d962f5f7e6.mp3?filename=chill-112198.mp3" autoplay loop></audio>
+
+  <nav id="navbar">
+    <div class="logo">Tribute to House</div>
+    <ul class="nav-links">
+      <li><a href="#hero">Home</a></li>
+      <li><a href="#about">About</a></li>
+      <li><a href="#next-event">Events</a></li>
+      <li><a href="#djs">DJs</a></li>
+      <li><a href="#contact">Send Set</a></li>
+    </ul>
+  </nav>
+
+  <header id="hero">
+    <div class="hero-content">
+      <h1>Tribute to House</h1>
+      <p class="subtitle">A movement of rhythm and unity</p>
+      <div class="cta-buttons">
+        <a href="#contact" class="btn">Send us your set</a>
+        <a href="#next-event" class="btn alt">Buy Tickets</a>
+      </div>
+    </div>
+  </header>
+
+  <section id="about">
+    <h2>About the Label</h2>
+    <p>Tribute to House is more than a label&mdash;it's a cultural movement. Our community of DJs spans the globe, united by the groove. We host unforgettable events celebrating the sound of house music worldwide.</p>
+  </section>
+
+  <section id="next-event" class="highlight">
+    <div class="event-info">
+      <h2>Next Event</h2>
+      <p class="date">June 30, 2024</p>
+      <h3 class="event-name">Sunset Beats Festival</h3>
+      <p class="location">Ibiza, Spain</p>
+      <p class="description">Join us on the beach for an evening of soulful house and dancing till dawn.</p>
+      <a href="#" class="btn alt">Buy Tickets</a>
+    </div>
+  </section>
+
+  <section id="upcoming">
+    <h2>Other Upcoming Events</h2>
+    <div class="event-cards">
+      <div class="card">
+        <p class="date">July 14</p>
+        <p class="name">Midnight Groove</p>
+        <p class="location">Berlin, Germany</p>
+      </div>
+      <div class="card">
+        <p class="date">August 21</p>
+        <p class="name">City Lights Party</p>
+        <p class="location">New York, USA</p>
+      </div>
+      <div class="card">
+        <p class="date">September 10</p>
+        <p class="name">Warehouse Reunion</p>
+        <p class="location">Chicago, USA</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="djs">
+    <h2>Featured Collabs / DJs</h2>
+    <div class="dj-grid">
+      <div class="dj-card">
+        <img src="https://via.placeholder.com/200x200" alt="DJ A">
+        <p>DJ A</p>
+      </div>
+      <div class="dj-card">
+        <img src="https://via.placeholder.com/200x200" alt="DJ B">
+        <p>DJ B</p>
+      </div>
+      <div class="dj-card">
+        <img src="https://via.placeholder.com/200x200" alt="DJ C">
+        <p>DJ C</p>
+      </div>
+      <div class="dj-card">
+        <img src="https://via.placeholder.com/200x200" alt="DJ D">
+        <p>DJ D</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="contact">
+    <h2>Send Us Your Set</h2>
+    <form id="contact-form">
+      <label>
+        Name
+        <input type="text" name="name" required>
+      </label>
+      <label>
+        Email
+        <input type="email" name="email" required>
+      </label>
+      <label>
+        Message
+        <textarea name="message" required></textarea>
+      </label>
+      <label>
+        Upload your mix
+        <input type="file" name="file">
+      </label>
+      <button type="submit" class="btn">Submit</button>
+      <p id="form-message" class="hidden">Thank you! We'll be in touch.</p>
+    </form>
+  </section>
+
+  <footer>
+    <div class="social">
+      <a href="#">Instagram</a>
+      <a href="#">SoundCloud</a>
+    </div>
+    <a href="#hero" class="to-top">Back to top</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const audio = document.getElementById('bg-audio');
+  setTimeout(() => {
+    if (audio) {
+      audio.muted = false;
+      audio.volume = 0.3;
+      audio.play().catch(() => {});
+    }
+  }, 500);
+
+  const form = document.getElementById('contact-form');
+  if (form) {
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      form.reset();
+      document.getElementById('form-message').classList.remove('hidden');
+    });
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,259 @@
+:root {
+  --purple: #2d004d;
+  --neon-purple: #a600ff;
+  --orange: #ff8c42;
+  --text: #ffffff;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: 'Montserrat', sans-serif;
+  background: var(--purple);
+  color: var(--text);
+}
+
+nav {
+  position: sticky;
+  top: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(45, 0, 77, 0.9);
+  padding: 10px 20px;
+  z-index: 1000;
+}
+
+nav .logo {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 700;
+  color: var(--orange);
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 700;
+  transition: color 0.3s;
+}
+
+nav a:hover {
+  color: var(--orange);
+}
+
+header#hero {
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: url('https://via.placeholder.com/1600x900') center/cover no-repeat;
+  text-align: center;
+  position: relative;
+}
+
+header#hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(45, 0, 77, 0.6);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-content h1 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 3rem;
+  margin: 0;
+}
+
+.subtitle {
+  margin-top: 0.5rem;
+  font-size: 1.2rem;
+  color: var(--orange);
+}
+
+.cta-buttons {
+  margin-top: 1.5rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.btn {
+  background: var(--orange);
+  color: var(--purple);
+  padding: 0.75rem 1.5rem;
+  text-decoration: none;
+  font-weight: bold;
+  border-radius: 4px;
+  transition: background 0.3s;
+}
+
+.btn:hover {
+  background: var(--neon-purple);
+  color: var(--text);
+}
+
+.btn.alt {
+  background: var(--neon-purple);
+  color: var(--text);
+}
+
+.btn.alt:hover {
+  background: var(--orange);
+  color: var(--purple);
+}
+
+section {
+  padding: 80px 20px;
+  text-align: center;
+}
+
+section h2 {
+  font-family: 'Orbitron', sans-serif;
+  margin-bottom: 20px;
+  color: var(--orange);
+}
+
+#next-event {
+  background: url('https://via.placeholder.com/1600x900/000000/ffffff') center/cover no-repeat;
+  position: relative;
+  color: var(--text);
+}
+
+#next-event::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(45, 0, 77, 0.7);
+}
+
+#next-event .event-info {
+  position: relative;
+  z-index: 1;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+#next-event .date {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+#next-event .event-name {
+  font-size: 2rem;
+  margin: 10px 0;
+}
+
+.event-cards {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding-bottom: 1rem;
+}
+
+.event-cards .card {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--neon-purple);
+  border-radius: 4px;
+  min-width: 200px;
+  padding: 1rem;
+}
+
+.dj-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.dj-card {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.dj-card img {
+  width: 100%;
+  border-radius: 4px;
+}
+
+form {
+  max-width: 500px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+form label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+}
+
+form input,
+form textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: none;
+}
+
+form button {
+  align-self: center;
+}
+
+.hidden {
+  display: none;
+}
+
+footer {
+  padding: 40px 20px;
+  background: rgba(45, 0, 77, 0.9);
+  text-align: center;
+}
+
+.social {
+  margin-bottom: 1rem;
+}
+
+.social a {
+  color: var(--text);
+  margin: 0 10px;
+  text-decoration: none;
+  transition: color 0.3s;
+}
+
+.social a:hover {
+  color: var(--orange);
+}
+
+.to-top {
+  color: var(--orange);
+  text-decoration: none;
+  font-weight: bold;
+}
+
+@media (max-width: 600px) {
+  .hero-content h1 {
+    font-size: 2rem;
+  }
+  nav ul {
+    gap: 10px;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive one-page website for **Tribute to House**
- style with neon purple and pastel orange palette
- enable smooth navigation and audio autoplay
- basic contact form mockup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688573c32320832384900d8337799c29