### PR TITLE
Add beat-based visual effects

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     analyser.connect(audioCtx.destination);
 
     const djTrain = document.querySelector('#hero .dj-train');
+    const bars = document.querySelectorAll('#hero .visualizer .bar');
     let beatTimeout;
 
     const detectBeat = () => {
@@ -25,9 +26,13 @@ document.addEventListener('DOMContentLoaded', () => {
       if (avg > 170) {
         if (djTrain) {
           djTrain.classList.add('on-beat');
-          clearTimeout(beatTimeout);
-          beatTimeout = setTimeout(() => djTrain.classList.remove('on-beat'), 100);
         }
+        bars.forEach(bar => bar.classList.add('on-beat'));
+        clearTimeout(beatTimeout);
+        beatTimeout = setTimeout(() => {
+          if (djTrain) djTrain.classList.remove('on-beat');
+          bars.forEach(bar => bar.classList.remove('on-beat'));
+        }, 100);
       }
       requestAnimationFrame(detectBeat);
     };

--- a/style.css
+++ b/style.css
@@ -273,6 +273,11 @@ footer {
   animation: bounce 1s infinite ease-in-out;
 }
 
+#hero .visualizer .bar.on-beat {
+  transform: scaleY(1.2);
+  background: var(--neon-purple);
+}
+
 #hero .visualizer .bar:nth-child(odd) {
   animation-delay: 0.5s;
 }


### PR DESCRIPTION
## Summary
- detect beats in background music
- animate visualizer bars and DJ train on beat
- style on-beat state for visualizer bars

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68863ec6c8a4832387ce94fa81b1bae1