### PR TITLE
Simplify audio player

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,6 @@
         <div class="vinyl" id="vinyl">
           <img src="src/media/logo_white.png" alt="Tribute to House">
         </div>
-        <button id="play-btn" aria-label="Play">&#9654;</button>
-        <div class="progress" id="progress">
-          <div class="progress-filled" id="progress-filled"></div>
-        </div>
         <audio id="bg-audio" src="src/player/track.wav" loop playsinline preload="metadata"></audio>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -43,42 +43,23 @@ document.addEventListener('DOMContentLoaded', () => {
       audioCtx.resume().catch(() => {});
     };
 
-    const playBtn = document.getElementById('play-btn');
-    const progressFilled = document.getElementById('progress-filled');
     const vinyl = document.getElementById('vinyl');
 
     // attempt autoplay on load
     tryPlay();
     requestAnimationFrame(detectBeat);
 
-    const updateButton = () => {
-      if (audio.paused) {
-        playBtn.textContent = '\u25BA';
-        playBtn.classList.remove('playing');
-        if (vinyl) vinyl.classList.remove('spinning');
-      } else {
-        playBtn.textContent = '\u275A\u275A';
-        playBtn.classList.add('playing');
-        if (vinyl) vinyl.classList.add('spinning');
-      }
-    };
-
-    if (playBtn && progressFilled) {
-      playBtn.addEventListener('click', () => {
+    if (vinyl) {
+      const updateVinyl = () => {
         if (audio.paused) {
-          tryPlay();
+          vinyl.classList.remove('spinning');
         } else {
-          audio.pause();
+          vinyl.classList.add('spinning');
         }
-      });
-
-      audio.addEventListener('play', updateButton);
-      audio.addEventListener('pause', updateButton);
-      audio.addEventListener('timeupdate', () => {
-        const percent = (audio.currentTime / audio.duration) * 100;
-        progressFilled.style.width = percent + '%';
-      });
-      updateButton();
+      };
+      audio.addEventListener('play', updateVinyl);
+      audio.addEventListener('pause', updateVinyl);
+      updateVinyl();
     }
 
     if (audio.paused) {

--- a/style.css
+++ b/style.css
@@ -334,7 +334,7 @@ footer {
 #audio-player .vinyl {
   width: 100%;
   aspect-ratio: 1 / 1;
-  opacity: 0.3;
+  opacity: 0.4;
   border-radius: 50%;
   background: radial-gradient(circle, #333 0%, #000 80%);
   position: relative;


### PR DESCRIPTION
## Summary
- strip play/pause controls from the vinyl player
- make the vinyl 40% transparent
- keep vinyl spinning when audio plays

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68864c8610d083239d200aa5ea5d8ddd