### PR TITLE
Add play button

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       <div class="vinyl" id="vinyl">
         <img src="src/media/logo_white.png" alt="Tribute to House">
       </div>
+      <button id="play-btn" class="hidden" aria-label="Play audio">&#9654;</button>
       <input type="range" id="volume-control" min="0" max="1" step="0.01" value="0.3" aria-label="volume">
       <audio id="bg-audio" src="src/player/track.wav" loop playsinline preload="metadata"></audio>
     </div>

--- a/script.js
+++ b/script.js
@@ -55,10 +55,23 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const vinyl = document.getElementById('vinyl');
+    const playBtn = document.getElementById('play-btn');
 
     // attempt autoplay on load
     tryPlay();
     requestAnimationFrame(detectBeat);
+
+    const updatePlayBtn = () => {
+      if (!playBtn) return;
+      if (audio.paused) {
+        playBtn.classList.remove('hidden');
+      } else {
+        playBtn.classList.add('hidden');
+      }
+    };
+    updatePlayBtn();
+    audio.addEventListener('play', updatePlayBtn);
+    audio.addEventListener('pause', updatePlayBtn);
 
     if (vinyl) {
       const updateVinyl = () => {
@@ -78,6 +91,16 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       });
       updateVinyl();
+    }
+
+    if (playBtn) {
+      playBtn.addEventListener('click', () => {
+        if (audio.paused) {
+          tryPlay();
+        } else {
+          audio.pause();
+        }
+      });
     }
 
     if (audio.paused) {

--- a/style.css
+++ b/style.css
@@ -364,6 +364,21 @@ footer {
   width: 100px;
 }
 
+#play-btn {
+  background: var(--orange);
+  color: var(--purple);
+  border: none;
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+#play-btn.hidden {
+  display: none;
+}
+
 
 #audio-player audio {
   display: none;


### PR DESCRIPTION
## Summary
- make the audio controls clearer by adding a play button
- style the new play button
- hook up play button logic in JS

## Testing
- `python3 - <<'PY'
import wave,contextlib,struct,math
with contextlib.closing(wave.open('src/player/track.wav','rb')) as w:
    frames_per_chunk=1024
    sum_abs=sum_sq=total_samples=0
    while True:
        frames=w.readframes(frames_per_chunk)
        if not frames:
            break
        samples=struct.unpack('<'+'h'*(len(frames)//2),frames)
        sum_abs+=sum(abs(x) for x in samples)
        sum_sq+=sum(x*x for x in samples)
        total_samples+=len(samples)
avg=sum_abs/total_samples
print('avg amplitude',avg)
PY`
- `python3 - <<'PY'
import wave,struct
with wave.open('src/player/track.wav','rb') as w:
    samples=struct.unpack('<'+'h'*(5*44100*w.getnchannels()),w.readframes(5*44100))
    print('nonzero count',sum(1 for s in samples if abs(s)>100))
PY`

------
https://chatgpt.com/codex/tasks/task_e_688668729d5083239eb82e26e507cf0b